### PR TITLE
Changed domain to preware.net

### DIFF
--- a/src/ca/canucksoftware/ipkg/PackageManager.java
+++ b/src/ca/canucksoftware/ipkg/PackageManager.java
@@ -38,13 +38,13 @@ public class PackageManager {
         bundle = WebOSQuickInstallApp.bundle;
         ALL_CATEGORIES = "--" + bundle.getString("ALL") + "--";
         defaultFeeds = new String[] {
-            "http://ipkg.preware.org/feeds/precentral/Packages.gz",
-            "http://ipkg.preware.org/feeds/webos-internals/all/Packages.gz",
-            "http://ipkg.preware.org/feeds/webos-internals/" + device.arch() + "/Packages.gz",
-            "http://ipkg.preware.org/feeds/webos-patches/" + device.version() + "/Packages.gz",
-            "http://ipkg.preware.org/feeds/webos-kernels/" + device.version() + "/Packages.gz",
+            "http://ipkg.preware.net/feeds/precentral/Packages.gz",
+            "http://ipkg.preware.net/feeds/webos-internals/all/Packages.gz",
+            "http://ipkg.preware.net/feeds/webos-internals/" + device.arch() + "/Packages.gz",
+            "http://ipkg.preware.net/feeds/webos-patches/" + device.version() + "/Packages.gz",
+            "http://ipkg.preware.net/feeds/webos-kernels/" + device.version() + "/Packages.gz",
             "http://www.prethemer.com/feeds/preware/themes/Packages.gz",
-            "http://ipkg.preware.org/feeds/precentral-themes/Packages.gz",
+            "http://ipkg.preware.net/feeds/precentral-themes/Packages.gz",
             "http://webos-clock-themer.googlecode.com/svn/trunk/WebOS%20Clock%20Theme%20Builder/feed/Packages.gz"
         };
         Preferences prefs = Preferences.systemRoot();

--- a/src/ca/canucksoftware/wosqi/Installer.java
+++ b/src/ca/canucksoftware/wosqi/Installer.java
@@ -90,7 +90,7 @@ public class Installer extends javax.swing.JDialog {
                 if(isPatch(name)) {
                     if(!containsPatch) {
                         webOS.sendScript(ScriptType.Patch);
-                        PackageFeed wosiFeed = PackageFeed.Download("http://ipkg.preware.org/feeds/webos-internals/all/Packages.gz");
+                        PackageFeed wosiFeed = PackageFeed.Download("http://ipkg.preware.net/feeds/webos-internals/all/Packages.gz");
                         int ausmtIndex = wosiFeed.indexOf("org.webosinternals.ausmt");
                         if(ausmtIndex>-1) {
                             okForPatch = patcher.meetsRequirements(wosiFeed.packages.get(ausmtIndex).getDownloadUrl());


### PR DESCRIPTION
Preware.org is no longer the hoster of the preware feeds, webOS
Internals is using preware.net now. See also:
http://pivotce.com/2014/08/29/preware-org-woes-feedssite-down-as-domain-slips-away/
